### PR TITLE
Update README.md to follow default node Func "start"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ subsequent invocations should look like:
             -noshell                                  \
             -pa gproc/ebin gproc/deps/gen_leader/ebin \
             -gproc gproc_dist all                     \
-            -s node1 run &
+            -s node1 &
     # launch node 2 and wait for it to finish and kill both nodes
     erl -name node2@127.0.0.1                         \
             -noshell                                  \
             -pa gproc/ebin gproc/deps/gen_leader/ebin \
             -gproc gproc_dist all                     \
-            -s node2 run 
+            -s node2
     node1 waiting to hear from somebody...
     node1 ok, so I see ['node2@127.0.0.1']
     node2 I can see ['node1@127.0.0.1']


### PR DESCRIPTION
commit:ea4c21 updates node1.erl and node2.erl with default node Func "start" but doesn't update the README.md. This PR is to fix that